### PR TITLE
Added PHEONIX model and gaia query back in

### DIFF
--- a/.github/workflows/flake8.yml
+++ b/.github/workflows/flake8.yml
@@ -12,6 +12,15 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.8
+
+    - name: Cache Poetry dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pypoetry
+        key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-poetry-
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,6 +16,15 @@ jobs:
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Cache Poetry dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pypoetry
+        key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-poetry-
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 sandbox
 src/pandorasat/data/old
+src/pandorasat/data/phoenix
 src/pandorasat/data/pandora_*_20220506.*
 src/pandorasat/data/pandora_*_20210602.*
 src/pandorasat/data/flatfield*.fits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pandorasat"
-version = "0.5.2"
+version = "0.5.3"
 description = ""
 authors = ["Christina Hedges <christina.l.hedges@nasa.gov>"]
 

--- a/src/pandorasat/__init__.py
+++ b/src/pandorasat/__init__.py
@@ -1,31 +1,28 @@
-__version__ = "0.5.2"
+__version__ = "0.5.3"
 # Standard library
 import os  # noqa
+from glob import glob
 
 PACKAGEDIR = os.path.abspath(os.path.dirname(__file__))
 
 # Standard library
 import logging  # noqa: E402
-from glob import glob  # noqa: E402
 
 pandorastyle = glob(f"{PACKAGEDIR}/data/pandora.mplstyle")
-
-
-from .utils import get_flatfield  # noqa: E402
 
 logging.basicConfig()
 logger = logging.getLogger("pandorasat")
 
-from .pandorasat import PandoraSat  # noqa
-
-flatnames = glob(f"{PACKAGEDIR}/data/flatfield_*.fits")
-if len(flatnames) == 0:
-    # Make a bogus flatfield
-    logger.warning("No flatfield file found. Generating a random one for you.")
-    get_flatfield()
-    logger.warning(
-        f"Generated flatfield in {PACKAGEDIR}/data/pandora_nir_20220506.fits."
-    )
-
 from .irdetector import NIRDetector  # noqa: E402, F401
+from .pandorasat import PandoraSat  # noqa
 from .visibledetector import VisibleDetector  # noqa: E402, F401
+
+# from
+# flatnames = glob(f"{PACKAGEDIR}/data/flatfield_*.fits")
+# if len(flatnames) == 0:
+#     # Make a bogus flatfield
+#     logger.warning("No flatfield file found. Generating a random one for you.")
+#     get_flatfield()
+#     logger.warning(
+#         f"Generated flatfield in {PACKAGEDIR}/data/pandora_nir_20220506.fits."
+#     )

--- a/src/pandorasat/irdetector.py
+++ b/src/pandorasat/irdetector.py
@@ -2,13 +2,11 @@
 
 # Standard library
 from dataclasses import dataclass
-from glob import glob
 
 # Third-party
 import astropy.units as u
 import numpy as np
 import pandas as pd
-from astropy.io import fits
 
 from . import PACKAGEDIR
 from .hardware import Hardware

--- a/src/pandorasat/irdetector.py
+++ b/src/pandorasat/irdetector.py
@@ -23,11 +23,11 @@ class NIRDetector:
 
     def __post_init__(self):
         """Some detector specific functions to run on initialization"""
-        self.flat = fits.open(
-            np.sort(
-                np.atleast_1d(glob(f"{PACKAGEDIR}/data/flatfield_NIRDA*.fits"))
-            )[-1]
-        )[1].data
+        # self.flat = fits.open(
+        #     np.sort(
+        #         np.atleast_1d(glob(f"{PACKAGEDIR}/data/flatfield_NIRDA*.fits"))
+        #     )[-1]
+        # )[1].data
 
     def __repr__(self):
         return "NIRDetector"

--- a/src/pandorasat/phoenix.py
+++ b/src/pandorasat/phoenix.py
@@ -1,0 +1,203 @@
+# Standard library
+import contextlib
+import functools
+import logging
+import os
+import warnings
+from glob import glob
+
+# Third-party
+import astropy.units as u
+import numpy as np
+import requests
+from astroquery import log as asqlog
+
+from . import PACKAGEDIR
+
+logging.basicConfig()
+logger = logging.getLogger("pandorasat")
+
+__all__ = [
+    "download_phoenix_grid",
+    "phoenixcontext",
+    "build_phoenix",
+    "get_phoenix_model",
+]
+
+PHOENIXPATH = f"{PACKAGEDIR}/data/phoenix/"
+PHOENIXGRIDPATH = f"{PACKAGEDIR}/data/phoenix/grid/phoenix/phoenixm00/"
+
+
+def download_file(file_url, file_path):
+    # Download the file from `file_url` and save it locally under `file_path`
+    with requests.get(file_url, stream=True) as r:
+        r.raise_for_status()
+        with open(file_path, "wb") as f:
+            for chunk in r.iter_content(chunk_size=8192):
+                f.write(chunk)
+
+
+def download_phoenix_grid():
+    # Standard library
+    import shutil
+    import tarfile
+
+    # Third-party
+    import numpy as np
+    from tqdm import tqdm
+
+    if os.path.isdir(PHOENIXPATH):
+        shutil.rmtree(PHOENIXPATH)
+    os.makedirs(PHOENIXGRIDPATH, exist_ok=True)
+    url = "https://archive.stsci.edu/hlsps/reference-atlases/cdbs/grid/phoenix/phoenixm00/"
+    page = requests.get(url).text
+    suffix = '.fits">'
+    filenames = np.asarray(
+        [
+            f"{i.split(suffix)[0]}.fits"
+            for i in page.split('<li>&#x1f4c4; <a href="')[2:]
+        ]
+    )
+    temperatures = np.asarray(
+        [int(name.split("_")[1].split(".fits")[0]) for name in filenames]
+    )
+    filenames, temperatures = (
+        filenames[np.argsort(temperatures)],
+        temperatures[np.argsort(temperatures)],
+    )
+    filenames = filenames[temperatures < 10000]
+    _ = [
+        download_file(f"{url}{filename}", f"{PHOENIXGRIDPATH}/{filename}")
+        for filename in tqdm(
+            filenames,
+            desc="Downloading PHOENIX Models",
+            leave=True,
+            position=0,
+        )
+    ]
+    download_file(
+        "http://ssb.stsci.edu/trds/tarfiles/synphot1.tar.gz",
+        f"{PHOENIXPATH}synphot1.tar.gz",
+    )
+    with tarfile.open(f"{PHOENIXPATH}synphot1.tar.gz") as tar:
+        tar.extractall(path=f"{PHOENIXPATH}")
+    os.remove(f"{PHOENIXPATH}synphot1.tar.gz")
+    fnames = glob(f"{PHOENIXPATH}grp/redcat/trds/*")
+    _ = [shutil.move(fname, f"{PHOENIXPATH}") for fname in fnames]
+    os.removedirs(f"{PHOENIXPATH}grp/redcat/trds/")
+    download_file(
+        "https://archive.stsci.edu/hlsps/reference-atlases/cdbs/grid/phoenix/catalog.fits",
+        f"{PHOENIXPATH}/grid/phoenix/catalog.fits",
+    )
+
+
+def build_phoenix():
+    # Check if the directory exists and has any files
+    os.makedirs(PHOENIXGRIDPATH, exist_ok=True)
+    if (
+        len(os.listdir(PHOENIXGRIDPATH)) == 65
+    ):  # The directory exists and has files in it
+        logger.debug(f"Found PHOENIX data in package in {PHOENIXGRIDPATH}.")
+    else:
+        logger.warning("No PHOENIX grid found, downloading grid.")
+        download_phoenix_grid()
+        logger.warning("PHEONIX grid downloaded.")
+
+
+def phoenixcontext():
+    """
+    Decorator that temporarily sets the `PYSYN_CDBS` environment variable.
+
+    Parameters
+    ----------
+    phoenixpath : str
+        The value to temporarily set for the `PYSYN_CDBS` environment variable.
+
+    Returns
+    -------
+    function
+        A wrapper function that sets `PYSYN_CDBS` to `phoenixpath` before
+        executing the decorated function and restores the original environment
+        afterwards.
+
+    Examples
+    --------
+    Using `set_pysyn_cdbs` to temporarily set `PYSYN_CDBS` for a function:
+
+    >>> @set_pysyn_cdbs()
+    ... def my_function():
+    ...     # Within this function, os.environ["PYSYN_CDBS"] is set
+    ...
+    >>> my_function()
+    >>> 'PYSYN_CDBS' in os.environ
+    False
+    """
+
+    def decorator(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            with modified_environ(PYSYN_CDBS=PHOENIXPATH):
+                return func(*args, **kwargs)
+
+        return wrapper
+
+    return decorator
+
+
+@contextlib.contextmanager
+def modified_environ(**update):
+    """
+    Temporarily updates the `os.environ` dictionary in-place and restores it upon exit.
+    """
+    env = os.environ
+    original_state = env.copy()
+
+    # Apply updates to the environment
+    env.update(update)
+
+    try:
+        yield
+    finally:
+        # Restore original environment
+        env.clear()
+        env.update(original_state)
+
+
+asqlog.setLevel("ERROR")
+
+
+@phoenixcontext()
+def get_phoenix_model(teff, logg=4.5, jmag=None, vmag=None):
+    build_phoenix()
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore", message="Extinction files not found in "
+        )
+        # Third-party
+        import pysynphot
+    print(os.environ["PYSYN_CDBS"])
+    logg1 = logg.value if isinstance(logg, u.Quantity) else logg
+    star = pysynphot.Icat(
+        "phoenix",
+        teff.value if isinstance(teff, u.Quantity) else teff,
+        0,
+        logg1 if np.isfinite(logg1) else 5,
+    )
+    if (jmag is not None) & (vmag is None):
+        star_norm = star.renorm(
+            jmag, "vegamag", pysynphot.ObsBandpass("johnson,j")
+        )
+    elif (jmag is None) & (vmag is not None):
+        star_norm = star.renorm(
+            vmag, "vegamag", pysynphot.ObsBandpass("johnson,V")
+        )
+    else:
+        raise ValueError("Input one of either `jmag` or `vmag`")
+    star_norm.convert("Micron")
+    star_norm.convert("flam")
+    mask = (star_norm.wave >= 0.1) * (star_norm.wave <= 3)
+    wavelength = star_norm.wave[mask] * u.micron
+    wavelength = wavelength.to(u.angstrom)
+
+    sed = star_norm.flux[mask] * u.erg / u.s / u.cm**2 / u.angstrom
+    return wavelength, sed

--- a/src/pandorasat/utils.py
+++ b/src/pandorasat/utils.py
@@ -1,9 +1,15 @@
+# Standard library
+import warnings
+from functools import lru_cache
+
 # Third-party
 import astropy.units as u
 import numpy as np
 from astropy.constants import c, h
+from astropy.coordinates import Distance, SkyCoord
 from astropy.io import fits
 from astropy.time import Time
+from astroquery.gaia import Gaia
 
 from . import PACKAGEDIR, __version__
 from .phoenix import get_phoenix_model
@@ -12,6 +18,97 @@ from .phoenix import get_phoenix_model
 def SED(teff, logg=4.5, jmag=None, vmag=None):
     """Gives a model SED for a given Teff, logg and magnitude."""
     return get_phoenix_model(teff, logg=logg, jmag=jmag, vmag=vmag)
+
+
+@lru_cache
+def get_sky_catalog(
+    ra=210.8023,
+    dec=54.349,
+    radius=0.155,
+    gbpmagnitude_range=(-3, 20),
+    limit=None,
+    gaia_keys=[
+        "source_id",
+        "ra",
+        "dec",
+        "parallax",
+        "pmra",
+        "pmdec",
+        "radial_velocity",
+        "ruwe",
+        "phot_bp_mean_mag",
+        "teff_gspphot",
+        "logg_gspphot",
+    ],
+):
+    """Gets a catalog of coordinates on the sky based on an input ra, dec and radius"""
+
+    query_str = f"""
+    SELECT {f'TOP {limit} ' if limit is not None else ''}* FROM (
+        SELECT gaia.{', gaia.'.join(gaia_keys)}, dr2.teff_val AS dr2_teff_val,
+        dr2.rv_template_logg AS dr2_logg, tmass.j_m, tmass.j_msigcom, tmass.ph_qual, DISTANCE(
+        POINT({u.Quantity(ra, u.deg).value}, {u.Quantity(dec, u.deg).value}),
+        POINT(gaia.ra, gaia.dec)) AS ang_sep,
+        EPOCH_PROP_POS(gaia.ra, gaia.dec, gaia.parallax, gaia.pmra, gaia.pmdec,
+        gaia.radial_velocity, gaia.ref_epoch, 2000) AS propagated_position_vector
+        FROM gaiadr3.gaia_source AS gaia
+        JOIN gaiadr3.tmass_psc_xsc_best_neighbour AS xmatch USING (source_id)
+        JOIN gaiadr3.dr2_neighbourhood AS xmatch2 ON gaia.source_id = xmatch2.dr3_source_id
+        JOIN gaiadr2.gaia_source AS dr2 ON xmatch2.dr2_source_id = dr2.source_id
+        JOIN gaiadr3.tmass_psc_xsc_join AS xjoin USING (clean_tmass_psc_xsc_oid)
+        JOIN gaiadr1.tmass_original_valid AS tmass ON
+        xjoin.original_psc_source_id = tmass.designation
+        WHERE 1 = CONTAINS(
+        POINT({u.Quantity(ra, u.deg).value}, {u.Quantity(dec, u.deg).value}),
+        CIRCLE(gaia.ra, gaia.dec, {(u.Quantity(radius, u.deg) + 50*u.arcsecond).value}))
+        AND gaia.parallax IS NOT NULL
+        AND gaia.phot_bp_mean_mag > {gbpmagnitude_range[0]}
+        AND gaia.phot_bp_mean_mag < {gbpmagnitude_range[1]}) AS subquery
+    WHERE 1 = CONTAINS(
+    POINT({u.Quantity(ra, u.deg).value}, {u.Quantity(dec, u.deg).value}),
+    CIRCLE(COORD1(subquery.propagated_position_vector), COORD2(subquery.propagated_position_vector), {u.Quantity(radius, u.deg).value}))
+    ORDER BY ang_sep ASC
+    """
+    job = Gaia.launch_job_async(query_str, verbose=False)
+    tbl = job.get_results()
+    if len(tbl) == 0:
+        raise ValueError("Could not find matches.")
+    plx = tbl["parallax"].value.filled(fill_value=0)
+    plx[plx < 0] = 0
+    cat = {
+        "jmag": tbl["j_m"].data.filled(np.nan),
+        "bmag": tbl["phot_bp_mean_mag"].data.filled(np.nan),
+        "ang_sep": tbl["ang_sep"].data.filled(np.nan) * u.deg,
+    }
+    cat["teff"] = (
+        tbl["teff_gspphot"].data.filled(
+            tbl["dr2_teff_val"].data.filled(np.nan)
+        )
+        * u.K
+    )
+    cat["logg"] = tbl["logg_gspphot"].data.filled(
+        tbl["dr2_logg"].data.filled(np.nan)
+    )
+    cat["RUWE"] = tbl["ruwe"].data.filled(99)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        cat["coords"] = SkyCoord(
+            ra=tbl["ra"].value.data * u.deg,
+            dec=tbl["dec"].value.data * u.deg,
+            pm_ra_cosdec=tbl["pmra"].value.filled(fill_value=0)
+            * u.mas
+            / u.year,
+            pm_dec=tbl["pmdec"].value.filled(fill_value=0) * u.mas / u.year,
+            obstime=Time.strptime("2016", "%Y"),
+            distance=Distance(parallax=plx * u.mas, allow_negative=True),
+            radial_velocity=tbl["radial_velocity"].value.filled(fill_value=0)
+            * u.km
+            / u.s,
+        ).apply_space_motion(Time.now())
+    cat["source_id"] = np.asarray(
+        [f"Gaia DR3 {i}" for i in tbl["source_id"].value.data]
+    )
+    return cat
 
 
 def photon_energy(wavelength):

--- a/src/pandorasat/utils.py
+++ b/src/pandorasat/utils.py
@@ -1,20 +1,17 @@
-# Standard library
-import os
-
 # Third-party
 import astropy.units as u
 import numpy as np
 from astropy.constants import c, h
 from astropy.io import fits
 from astropy.time import Time
-from astroquery import log as asqlog
 
 from . import PACKAGEDIR, __version__
+from .phoenix import get_phoenix_model
 
-phoenixpath = f"{PACKAGEDIR}/data/phoenix"
-os.environ["PYSYN_CDBS"] = phoenixpath
 
-asqlog.setLevel("ERROR")
+def SED(teff, logg=4.5, jmag=None, vmag=None):
+    """Gives a model SED for a given Teff, logg and magnitude."""
+    return get_phoenix_model(teff, logg=logg, jmag=jmag, vmag=vmag)
 
 
 def photon_energy(wavelength):
@@ -22,7 +19,7 @@ def photon_energy(wavelength):
     return ((h * c) / wavelength) * 1 / u.photon
 
 
-def get_flatfield(stddev=0.005, seed=777):
+def simulate_flatfield(stddev=0.005, seed=777):
     np.random.seed(seed)
     """ This generates and writes a dummy flatfield file. """
     for detector in ["VISDA", "NIRDA"]:

--- a/src/pandorasat/visibledetector.py
+++ b/src/pandorasat/visibledetector.py
@@ -22,11 +22,11 @@ class VisibleDetector:
 
     def __post_init__(self):
         """Some detector specific functions to run on initialization"""
-        self.flat = fits.open(
-            np.sort(
-                np.atleast_1d(glob(f"{PACKAGEDIR}/data/flatfield_VISDA*.fits"))
-            )[-1]
-        )[1].data
+        # self.flat = fits.open(
+        #     np.sort(
+        #         np.atleast_1d(glob(f"{PACKAGEDIR}/data/flatfield_VISDA*.fits"))
+        #     )[-1]
+        # )[1].data
         if hasattr(self, "fieldstop_radius"):
             C, R = (
                 np.mgrid[

--- a/src/pandorasat/visibledetector.py
+++ b/src/pandorasat/visibledetector.py
@@ -1,13 +1,12 @@
 """Holds metadata and methods on Pandora VISDA"""
 # Standard library
 from dataclasses import dataclass
-from glob import glob
 
 # Third-party
 import astropy.units as u
 import numpy as np
 import pandas as pd
-from astropy.io import fits, votable
+from astropy.io import votable
 
 from . import PACKAGEDIR
 from .hardware import Hardware

--- a/tests/test_detectors.py
+++ b/tests/test_detectors.py
@@ -6,13 +6,9 @@ import astropy.units as u
 import numpy as np
 
 # First-party/Local
-from pandorasat import PACKAGEDIR, PandoraSat, __version__
+from pandorasat import PACKAGEDIR, PandoraSat
 from pandorasat.irdetector import NIRDetector
 from pandorasat.visibledetector import VisibleDetector
-
-
-def test_version():
-    assert __version__ == "0.5.2"
 
 
 # Check NIR and Visible detectors have the correct sensitivity

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,6 +6,7 @@ from glob import glob
 import astropy.units as u
 import numpy as np
 import pytest
+from astropy.coordinates import SkyCoord
 
 # First-party/Local
 from pandorasat import PACKAGEDIR, utils
@@ -45,6 +46,18 @@ def test_load_vega():
     assert len(wav) > 0
     assert len(spec) > 0
     return
+
+
+def test_get_skycatalog():
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        pytest.skip(
+            "Skipping this test on GitHub Actions because this requires an database query."
+        )
+    cat = utils.get_sky_catalog(radius=0.05)
+    assert isinstance(cat, dict)
+    assert isinstance(cat["coords"], SkyCoord)
+    assert len(cat["coords"]) > 0
+    assert "jmag" in cat.keys()
 
 
 def test_get_phoenix():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from glob import glob
 # Third-party
 import astropy.units as u
 import numpy as np
+import pytest
 
 # First-party/Local
 from pandorasat import PACKAGEDIR, utils
@@ -19,8 +20,11 @@ def test_photon_energy():
 
 
 # test get_flatfield
-def test_get_flatfield():
-    utils.get_flatfield()
+@pytest.mark.skip(
+    reason="Creates a large file, we do not need this right now."
+)
+def test_simulate_flatfield():
+    utils.simulate_flatfield()
 
     # Check that files were made for NIRDA and VISDA
     assert len(glob(f"{PACKAGEDIR}/data/flatfield_NIRDA*.fits")) > 0
@@ -41,3 +45,21 @@ def test_load_vega():
     assert len(wav) > 0
     assert len(spec) > 0
     return
+
+
+def test_get_phoenix():
+    if os.getenv("GITHUB_ACTIONS") == "true":
+        pytest.skip(
+            "Skipping this test on GitHub Actions this downloads a database of stellar models."
+        )
+
+    wavelength, sed = utils.SED(teff=5000, jmag=9)
+    assert len(wavelength) == len(sed)
+    try:
+        u.Quantity(wavelength, u.AA)
+    except u.UnitConversionError:
+        pytest.fail("Incorrect units")
+    try:
+        u.Quantity(sed, u.erg / (u.AA * u.s * u.cm**2))
+    except u.UnitConversionError:
+        pytest.fail("Incorrect units")


### PR DESCRIPTION
We're going to need some phoenix models for almost every package to do some testing. This is pretty fundamental and we 

a) want to easily be able to install the necessary grid files
b) want to install them in **one place only**
c) want to be able to get the spectrum easily without a headache
d) do not want to overwrite the environment variables that allow us to work with pysynphot all the time, in case science team uses that tool and has a bigger better grid.

I made it so this tool will download the necessary grid files for you, only if you ask for them, store them in the right place and then set up the environment variables for them.

I also think we need a target search all the time, so I put that back in utils for now. We can think about where else it might be, but for now I need it in all the upstream packages...!