### PR TITLE
adding missing documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -9,7 +9,7 @@ This Python package contains metadata for Pandora and **basic** functions descri
 To install you can use
 
 ```
-pip install pandora-sat --upgrade
+pip install pandorasat --upgrade
 ```
 
 You should update your package often, as we frequently put out new versions with updated Current Best Estimates, and some limited new functionality. Check your version number using

--- a/docs/info/NIRDA.md
+++ b/docs/info/NIRDA.md
@@ -1,11 +1,11 @@
-|                     | NIRDA                                         |
-|:--------------------|:----------------------------------------------|
-| Detector Size       | (2048, 2048)                                  |
-| Subarray Size       | (400, 80)                                     |
-| Pixel Scale         | 1.19 $\mathrm{\frac{{}^{\prime\prime}}{pix}}$ |
-| Pixel Size          | 18.0 $\mathrm{\frac{\mu m}{pix}}$             |
-| Dark Noise          | 1.0 $\mathrm{\frac{e^{-}}{s}}$                |
-| Wavelength Midpoint | 1.33 $\mathrm{\mu m}$                         |
-| Pixel Read Time     | 1.0e-05 $\mathrm{\frac{s}{pix}}$              |
-| Zeropoint           | 3.098e-10$\mathrm{\frac{erg}{A\,s\,cm^{2}}}$  |
-| R @ 1.3$\mu m$      | 65                                            |
+|                     | NIRDA                                         | pandorasat property      |
+|:--------------------|:----------------------------------------------|--------------------------|
+| Detector Size       | (2048, 2048)                                  | shape                    |
+| Subarray Size       | (400, 80)                                     | subarray_size            |
+| Pixel Scale         | 1.19 $\mathrm{\frac{{}^{\prime\prime}}{pix}}$ | pixel_scale              |
+| Pixel Size          | 18.0 $\mathrm{\frac{\mu m}{pix}}$             | pixel_size               |
+| Dark Noise          | 1.0 $\mathrm{\frac{e^{-}}{s}}$                | dark                     |
+| Wavelength Midpoint | 1.33 $\mathrm{\mu m}$                         | midpoint                 |
+| Pixel Read Time     | 1.0e-05 $\mathrm{\frac{s}{pix}}$              | pixel_read_time          |
+| Zeropoint           | 3.098e-10$\mathrm{\frac{erg}{A\,s\,cm^{2}}}$  | estimate_zeropoint()     |
+| R @ 1.3$\mu m$      | 65                                            |                          | 

--- a/docs/info/VISDA.md
+++ b/docs/info/VISDA.md
@@ -1,11 +1,11 @@
-|                     | VISDA                                         |
-|:--------------------|:----------------------------------------------|
-| Detector Size       | (2048, 2048)                                  |
-| Pixel Scale         | 0.78 $\mathrm{\frac{{}^{\prime\prime}}{pix}}$ |
-| Pixel Size          | 6.5 $\mathrm{\frac{\mu m}{pix}}$              |
-| Read Noise          | 1.5 $\mathrm{e^{-}}$                          |
-| Dark Noise          | 1.0 $\mathrm{\frac{e^{-}}{s}}$                |
-| Bias                | 100.0 $\mathrm{e^{-}}$                        |
-| Wavelength Midpoint | 0.56 $\mathrm{\mu m}$                         |
-| Integration Time    | 0.2 $\mathrm{s}$                              |
-| Zeropoint           | 3.777e-09$\mathrm{\frac{erg}{A\,s\,cm^{2}}}$  |
+|                     | VISDA                                         | pandorasat property    |
+|:--------------------|:----------------------------------------------|------------------------|
+| Detector Size       | (2048, 2048)                                  | shape                  |  
+| Pixel Scale         | 0.78 $\mathrm{\frac{{}^{\prime\prime}}{pix}}$ | pixel_scale            |
+| Pixel Size          | 6.5 $\mathrm{\frac{\mu m}{pix}}$              | pixel_size             |
+| Read Noise          | 1.5 $\mathrm{e^{-}}$                          | read_noise             |
+| Dark Noise          | 1.0 $\mathrm{\frac{e^{-}}{s}}$                | dark                   |
+| Bias                | 100.0 $\mathrm{e^{-}}$                        | bias                   |
+| Wavelength Midpoint | 0.56 $\mathrm{\mu m}$                         | midpoint               |
+| Integration Time    | 0.2 $\mathrm{s}$                              | integration_time       |
+| Zeropoint           | 3.777e-09$\mathrm{\frac{erg}{A\,s\,cm^{2}}}$  | estimate_zeropoint     |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,9 @@ nav:
   - Home: README.md
   - NIR Detector: irdetector.md
   - Visible Detector: visibledetector.md
+  - Hardware: hardware.md
+  - Orbit: orbit.md
+  
 theme:
   name: "material"
   icon:

--- a/src/pandorasat/irdetector.py
+++ b/src/pandorasat/irdetector.py
@@ -49,6 +49,7 @@ class NIRDetector(DetectorMixins):
 
     @property
     def bits_per_pixel(self):
+        """Number of bits per pixel"""
         return 16 * u.bit / u.pixel
 
     @property
@@ -67,39 +68,48 @@ class NIRDetector(DetectorMixins):
 
     @property
     def pixel_read_time(self):
+        """Pixel read time"""
         return 1e-5 * u.second / u.pixel
 
     @property
     def subarray_size(self):
+        """Size of standard subarray"""
         return (400, 80)
 
     def frame_time(self, array_size=None):
+        """Time to read out one frame of the subarray"""
         if array_size is None:
             array_size = self.subarray_size
         return np.prod(array_size) * u.pixel * self.pixel_read_time
 
     @property
     def dark(self):
+        """Dark noise"""
         return 1 * u.electron / u.second
 
     @property
     def read_noise(self):
+        """Read noise"""
         return 22 * u.electron
 
     @property
     def bias(self):
+        """NIRDA detector bias"""
         return 46000 * u.electron
 
     @property
     def bias_uncertainty(self):
+        "Uncertainty in NIRDA detector bias"
         return (185 * 2) * u.electron
 
     @property
     def saturation_limit(self):
+        "NIRDA saturation limit"
         raise ValueError("Not Set")
 
     @property
     def non_linearity(self):
+        "NIRDA non linearity"
         raise ValueError("Not Set")
 
     def throughput(self, wavelength: u.Quantity):
@@ -112,6 +122,7 @@ class NIRDetector(DetectorMixins):
 
     @property
     def gain(self):
+        "detector gain"
         return 0.5 * u.electron / u.DN
 
     def apply_gain(self, values: u.Quantity):
@@ -236,4 +247,5 @@ class NIRDetector(DetectorMixins):
 
     @property
     def background_rate(self):
+        "NIRDA background rate"
         return 4 * u.electron / u.second

--- a/src/pandorasat/mixins.py
+++ b/src/pandorasat/mixins.py
@@ -33,6 +33,7 @@ class DetectorMixins:
         )
 
     def plot_sensitivity(self, ax=None):
+        """Plot the sensitivity of the detector as a function of wavelength"""
         if ax is None:
             _, ax = plt.subplots()
         with plt.style.context(PANDORASTYLE):

--- a/src/pandorasat/visibledetector.py
+++ b/src/pandorasat/visibledetector.py
@@ -98,7 +98,7 @@ class VisibleDetector(DetectorMixins):
 
     @property
     def bias(self):
-        """Detector bias""""
+        """Detector bias"""
         return 100 * u.electron
 
     @property

--- a/src/pandorasat/visibledetector.py
+++ b/src/pandorasat/visibledetector.py
@@ -69,6 +69,7 @@ class VisibleDetector(DetectorMixins):
 
     @property
     def bits_per_pixel(self):
+        """Number of bits per pixel"""
         return 32 * u.bit / u.pixel
 
     @property
@@ -87,25 +88,31 @@ class VisibleDetector(DetectorMixins):
 
     @property
     def dark(self):
+        """Dark Noise"""
         return 1 * u.electron / u.second
 
     @property
     def read_noise(self):
+        """Read Noise"""
         return 1.5 * u.electron
 
     @property
     def bias(self):
+        """Detector bias""""
         return 100 * u.electron
 
     @property
     def integration_time(self):
+        "Integration time"
         return 0.2 * u.second
 
     @property
     def fieldstop_radius(self):
+        "Radius of the fieldstop"
         return 6.5 * u.mm
 
     def throughput(self, wavelength: u.Quantity):
+        """Throughput at the specified wavelength(s)"""
         df = pd.read_csv(f"{PACKAGEDIR}/data/dichroic-transmission.csv")
         throughput = (
             100 - np.interp(wavelength.to(u.nm).value, *np.asarray(df).T)
@@ -263,4 +270,5 @@ class VisibleDetector(DetectorMixins):
 
     @property
     def background_rate(self):
+        """Detector background rate"""
         return 2 * u.electron / u.second


### PR DESCRIPTION
Candidate changes after reviewing the documentation:

- updated erroneous pip command
- added simple comments to a bunch of the properties because I think that's how to get the info into the API documentation
- added an additional column to the tables on the VIS and NIR documentation pages to specify the pandora-sat property for the specified quantity
- added a couple lines to the mkdocs.yml because I *think* that might expand the docs to include the hardware and orbit properties

Important note!!!  I haven't used this method to make docs before and it's been *years* since I've done a pull request -- so let me know what I can do better!!!!